### PR TITLE
Put a trim area around the canvas to accommodate the selection

### DIFF
--- a/src/components/Selection.tsx
+++ b/src/components/Selection.tsx
@@ -21,13 +21,6 @@ import { Tile } from '../model/tile-generator';
 import { assertExists } from '../utils/type-utils';
 import { spread } from 'lodash';
 
-export type Selection = {
-  startRow: number;
-  startColumn: number;
-  endRow: number;
-  endColumn: number;
-};
-
 export type Hit = {
   x: number;
   y: number;

--- a/src/model/geometry.ts
+++ b/src/model/geometry.ts
@@ -114,19 +114,19 @@ export class TileRect implements Iterable<number> {
 
   intersect(other: TileRect) {
     const left =
-      other.contains(this.leftMiddle) && other.contains(this.topMiddle) && other.contains(this.bottomMiddle)
+      other.contains(this.leftMiddle) && other.top <= this.top && other.bottom >= this.bottom
         ? Math.max(this.left, other.right)
         : this.left;
     const top =
-      other.contains(this.topMiddle) && other.contains(this.leftMiddle) && other.contains(this.rightMiddle)
+      other.contains(this.topMiddle) && other.left <= this.left && other.right >= this.right
         ? Math.max(this.top, other.bottom)
         : this.top;
     const right =
-      other.contains(this.rightMiddle) && other.contains(this.topMiddle) && other.contains(this.bottomMiddle)
+      other.contains(this.rightMiddle) && other.top <= this.top && other.bottom >= this.bottom
         ? Math.min(this.right, other.left)
         : this.right;
     const bottom =
-      other.contains(this.bottomMiddle) && other.contains(this.leftMiddle) && other.contains(this.rightMiddle)
+      other.contains(this.bottomMiddle) && other.left <= this.left && other.right >= this.right
         ? Math.min(this.bottom, other.top)
         : this.bottom;
 


### PR DESCRIPTION
- expand the canvas and translate its origin to accommodate a trim area around the outside into which the selection rectangle can extend
- clear the canvas on each paint to erase old selection content in the new trim area
- addition of the trim exposed a latent bug in the cropping of the ragged edges, fixed herein

Fixes #3